### PR TITLE
Fix NPM distribution

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import { fixProtocollessUrls } from "./fixProtocollessUrls";
-import { generateInterceptorScript } from "./generateInterceptorScript";
+import { fixProtocollessUrls } from "./fixProtocollessUrls.js";
+import { generateInterceptorScript } from "./generateInterceptorScript.js";
 import type { FileCollection } from "./types";
 export * from "./types";
 


### PR DESCRIPTION
Should fix the error on import:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module 'node_modules/magic-sandbox/dist/fixProtocollessUrls' imported from node_modules/magic-sandbox/dist/index.js
    at finalizeResolution (node:internal/modules/esm/resolve:257:11)
    at moduleResolve (node:internal/modules/esm/resolve:914:10)
    at defaultResolve (node:internal/modules/esm/resolve:1038:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:557:12)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:525:25)
    at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:246:38)
    at ModuleJob._link (node:internal/modules/esm/module_job:126:49) {
  code: 'ERR_MODULE_NOT_FOUND',
}

```